### PR TITLE
Update title and add responsive text scaling

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
     </style>
 </head>
 <body>
-    <div class="coming-soon-text">COMING SOON</div>
+    <div class="coming-soon-text">WELCOME TO SUTRION</div>
     
     <script type="module">
         import * as THREE from "https://cdn.skypack.dev/three@0.136.0";

--- a/index.html
+++ b/index.html
@@ -47,19 +47,6 @@
             }
         }
         
-        @media (max-width: 768px) {
-            .coming-soon-text {
-                font-size: 2.5rem;
-                letter-spacing: 0.3rem;
-            }
-        }
-        
-        @media (max-width: 480px) {
-            .coming-soon-text {
-                font-size: 1.8rem;
-                letter-spacing: 0.2rem;
-            }
-        }
     </style>
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Welcome to Sutrion</title>
+    <title>Sutrion is Coming Soon</title>
     <style>
         body {
             margin: 0;
@@ -60,7 +60,7 @@
     </style>
 </head>
 <body>
-    <div class="coming-soon-text">WELCOME TO SUTRION</div>
+    <div class="coming-soon-text">SUTRION IS COMING SOON</div>
     
     <script type="module">
         import * as THREE from "https://cdn.skypack.dev/three@0.136.0";

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Sutrion - Coming Soon</title>
+    <title>Welcome to Sutrion</title>
     <style>
         body {
             margin: 0;

--- a/index.html
+++ b/index.html
@@ -19,9 +19,9 @@
             left: 50%;
             transform: translate(-50%, -50%);
             color: #fff;
-            font-size: 4rem;
+            font-size: clamp(1.5rem, 8vw, 4rem);
             font-weight: bold;
-            letter-spacing: 0.5rem;
+            letter-spacing: clamp(0.1rem, 1vw, 0.5rem);
             text-align: center;
             z-index: 100;
             white-space: nowrap;
@@ -29,6 +29,9 @@
                          0 0 40px rgba(100, 50, 255, 0.6),
                          0 0 60px rgba(227, 155, 0, 0.4);
             animation: glow 2s ease-in-out infinite alternate;
+            padding: 0 1rem;
+            max-width: 95vw;
+            overflow: hidden;
         }
         
         @keyframes glow {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,13 @@
 {
-  "name": "code",
+  "name": "sutrion-website",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
-  "packages": {}
+  "packages": {
+    "": {
+      "name": "sutrion-website",
+      "version": "1.0.0",
+      "license": "ISC"
+    }
+  }
 }


### PR DESCRIPTION
## Purpose
The user wanted to update the page title to "Sutrion is coming soon" and implement responsive text scaling so that the text automatically adjusts to smaller window sizes while staying visible on the page.

## Code changes
- **Title update**: Changed page title from "Sutrion - Coming Soon" to "Sutrion is Coming Soon"
- **Text content**: Updated main text from "COMING SOON" to "SUTRION IS COMING SOON"
- **Responsive typography**: Replaced fixed font-size with `clamp(1.5rem, 8vw, 4rem)` for automatic scaling
- **Responsive spacing**: Updated letter-spacing to use `clamp(0.1rem, 1vw, 0.5rem)`
- **Layout improvements**: Added padding, max-width, and overflow handling for better mobile display
- **Code cleanup**: Removed redundant media queries that are now handled by clamp()
- **Package metadata**: Updated package.json with proper name and version

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/6acf346cbb7a4f3193bc9e762155c10d/neon-landing)

👀 [Preview Link](https://6acf346cbb7a4f3193bc9e762155c10d-neon-landing.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>6acf346cbb7a4f3193bc9e762155c10d</projectId>-->
<!--<branchName>neon-landing</branchName>-->