### PR TITLE
Fix mobile text wrapping for coming soon message

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,11 @@
                 white-space: normal;
                 line-height: 1.2;
             }
+
+            .mobile-break::before {
+                content: "\A";
+                white-space: pre;
+            }
         }
         
         @keyframes glow {

--- a/index.html
+++ b/index.html
@@ -33,6 +33,13 @@
             max-width: 95vw;
             overflow: hidden;
         }
+
+        @media (max-width: 768px) {
+            .coming-soon-text {
+                white-space: normal;
+                line-height: 1.2;
+            }
+        }
         
         @keyframes glow {
             from {

--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
     </style>
 </head>
 <body>
-    <div class="coming-soon-text">SUTRION IS COMING SOON</div>
+    <div class="coming-soon-text">SUTRION IS COMING <span class="mobile-break">SOON</span></div>
     
     <script type="module">
         import * as THREE from "https://cdn.skypack.dev/three@0.136.0";


### PR DESCRIPTION
## Purpose
Improve mobile browser display by ensuring the "SUTRION IS COMING SOON" text either displays fully on one line or breaks appropriately with "SOON" on a separate line for better readability on iPhone browsers.

## Code changes
- Added responsive CSS media query for screens under 768px width
- Modified `.coming-soon-text` to allow normal text wrapping on mobile devices
- Added `.mobile-break` class with CSS pseudo-element to force line break before "SOON"
- Updated HTML to wrap "SOON" in a span with the mobile-break class for controlled line breaking

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/6acf346cbb7a4f3193bc9e762155c10d/pixel-space)

👀 [Preview Link](https://6acf346cbb7a4f3193bc9e762155c10d-pixel-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>6acf346cbb7a4f3193bc9e762155c10d</projectId>-->
<!--<branchName>pixel-space</branchName>-->